### PR TITLE
catch all errors inside onerror

### DIFF
--- a/public/onerror.js
+++ b/public/onerror.js
@@ -1,6 +1,10 @@
 window.onerror = function(errorMsg, file, lineNumber) {
-    var url = window.location.href;
-    var logUrl = '/log?msg=' + encodeURIComponent(errorMsg) + '&url=' + encodeURIComponent(url);
+    try {
+        var url = window.location.href;
+        var logUrl = '/log?msg=' + encodeURIComponent(errorMsg) + '&url=' + encodeURIComponent(url);
 
-    new Image().src = logUrl;
+        new Image().src = logUrl;
+    } catch(e) {
+        // we don't want errors to throw inside onerror
+    }
 };


### PR DESCRIPTION
For å forsikre oss at det ikke kastes noen feil fra `onerror`, er det vel best å wrappe alt i en `try/catch`
